### PR TITLE
Added fix for detecting client side hash change

### DIFF
--- a/src/utils/isOnlyHrefHashChange.js
+++ b/src/utils/isOnlyHrefHashChange.js
@@ -3,16 +3,21 @@
  */
 
 const isOnlyHrefHashChange = (a, b) => {
-  if (a === b) {
-    return true;
-  }
   if (!a || !b) {
     return false;
   }
+
+  if (!a.includes('#') || !b.includes('#')) {
+    return false;
+  }
+
+  // If there is a hash, but the string before the hash matches, then it is a
+  // hash only change. If the hash values are mismatching, or the same, it does
+  // not matter because the browser will deal with that.
   if (a.split('#')[0] === b.split('#')[0]) {
     return true;
   }
-  // TODO: check for relative href
+
   return false;
 };
 

--- a/test/utils/isOnlyHrefHashChange.js
+++ b/test/utils/isOnlyHrefHashChange.js
@@ -1,0 +1,44 @@
+import test from 'ava';
+import 'babel-core/register';
+
+import isOnlyHrefHashChange from 'redux-router-kit/src/utils/isOnlyHrefHashChange';
+
+test('will return `false` if the first or second location do not exist', t => {
+  const locationA = undefined;
+  const locationB = undefined;
+
+  const result = isOnlyHrefHashChange(locationA, locationB);
+  const expected = false;
+
+  t.is(result, expected);
+});
+
+test('will return `false` if the first or second location does not contain a hash', t => {
+  const locationA = 'http://www.localhost:8000/app/explore';
+  const locationB = 'http://www.localhost:8000/app/explore';
+
+  const result = isOnlyHrefHashChange(locationA, locationB);
+  const expected = false;
+
+  t.is(result, expected);
+});
+
+test('will return `true` if both strings contain a hash and the base values are the same', t => {
+  const locationA = 'http://www.localhost:8000/app/explore/#/hello-world';
+  const locationB = 'http://www.localhost:8000/app/explore/#/hello-world-part-2';
+
+  const result = isOnlyHrefHashChange(locationA, locationB);
+  const expected = true;
+
+  t.is(result, expected);
+});
+
+test('will return `false` if both strings contain a hash and the base values are different', t => {
+  const locationA = 'http://www.localhost:8000/app/contact-us/#/hello-world';
+  const locationB = 'http://www.localhost:8000/app/explore/#/hello-world';
+
+  const result = isOnlyHrefHashChange(locationA, locationB);
+  const expected = false;
+
+  t.is(result, expected);
+});


### PR DESCRIPTION
Fixes an issue where if the same locations were passed, e.g. `isOnlyHrefHashChange ('http://localhost:8000/app/explore', 'http://localhost:8000/app/explore');` it would be interpreted as a hash change in the [History](https://github.com/zapier/redux-router-kit/blob/f4c8c253917831add969dd4cc66cb8f74836c40e/src/components/History.js#L61-L63) component. 

This modifies that behaviour so that the above case would prevent the default event from occuring.