### PR TITLE
Fix spelling mistake

### DIFF
--- a/src/middleware/createRouterMiddleware.js
+++ b/src/middleware/createRouterMiddleware.js
@@ -195,7 +195,7 @@ const createRouterMiddleware = ({
           payload: {
             ...action.payload,
             event: cleanEvent(action.payload.event || {}),
-            isHistoryChage: action.payload.isHistoryChage
+            isHistoryChange: action.payload.isHistoryChange
           },
           meta: {
             url,


### PR DESCRIPTION
I don't believe this impacts anything significantly today, but I found it while debugging an issue. I've only seen one usage of this property [here](https://github.com/zapier/zapier/blob/develop/assets/app/login/routes.js#L49)