### PR TITLE
Add action to modify location origin

### DIFF
--- a/src/ActionTypes.js
+++ b/src/ActionTypes.js
@@ -10,6 +10,7 @@ export const ROUTE_TO_WINDOW = '@@redux-router-kit/ROUTE_TO_WINDOW';
 export const ROUTE_TO_EXIT = '@@redux-router-kit/ROUTE_TO_EXIT';
 export const CANCEL_ROUTE = '@@redux-router-kit/CANCEL_ROUTE';
 export const MODIFY_ROUTE = '@@redux-router-kit/MODIFY_ROUTE';
+export const MODIFY_LOCATION = '@@redux-router-kit/MODIFY_LOCATION';
 
 export default {
   ROUTE_TO_INIT,
@@ -19,5 +20,6 @@ export default {
   ROUTE_TO_WINDOW,
   ROUTE_TO_EXIT,
   CANCEL_ROUTE,
-  MODIFY_ROUTE
+  MODIFY_ROUTE,
+  MODIFY_LOCATION
 };

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -10,10 +10,9 @@ const defaultState = {
   next: null
 };
 
-const undefinedAsNull = value => value === undefined ? null : value;
+const undefinedAsNull = value => (value === undefined ? null : value);
 
 const handlers = {
-
   /**
    * Wipe out the next route.
    */
@@ -116,6 +115,21 @@ const handlers = {
       },
       next: null,
       origin: state.origin || meta.location.origin
+    };
+  },
+
+  /**
+   * Set the `location` value in state, this is used in SSR mode to ensure that
+   * client-side links navigate correctly.
+   */
+  [ActionTypes.MODIFY_LOCATION](state, action) {
+    return {
+      ...state,
+      origin: action.payload.location.origin,
+      current: {
+        ...state.current,
+        location: action.payload.location
+      }
     };
   }
 };

--- a/test/dispatch-actions.js
+++ b/test/dispatch-actions.js
@@ -42,15 +42,14 @@ const createRoutes = () => ({
 });
 
 const createStoreWithMiddleware = compose(
-  applyMiddleware(
-    createRouterMiddleware({routes: createRoutes()})
-  )
+  applyMiddleware(createRouterMiddleware({ routes: createRoutes() }))
 )(createStore);
 
 const createStoreWithRoutes = routes => {
-  return createStore(reducer, applyMiddleware(
-    createRouterMiddleware({routes})
-  ));
+  return createStore(
+    reducer,
+    applyMiddleware(createRouterMiddleware({ routes }))
+  );
 };
 
 test('dispatch routeTo', t => {
@@ -60,50 +59,50 @@ test('dispatch routeTo', t => {
   let router = store.getState().router;
   t.is(router.next.url, '/todos');
   t.is(router.current, null);
-  return result
-    .then(() => {
-      router = store.getState().router;
-      t.is(router.current.url, '/todos');
-      const routeList = findRoutes(routes, router.current.routeKey);
-      t.is(routeList[0].name, 'todos');
-      t.true(router.current.isTodosRoute);
-    });
+  return result.then(() => {
+    router = store.getState().router;
+    t.is(router.current.url, '/todos');
+    const routeList = findRoutes(routes, router.current.routeKey);
+    t.is(routeList[0].name, 'todos');
+    t.true(router.current.isTodosRoute);
+  });
 });
 
 test('dispatch routeTo for nested route', t => {
   const routes = createRoutes();
   const store = createStoreWithRoutes(routes);
-  store.dispatch(routeTo('/todos/123'))
-    .then(() => {
-      const router = store.getState().router;
-      t.is(router.current.url, '/todos/123');
-      t.same(router.current.params, {id: '123'});
-      const routeList = findRoutes(routes, router.current.routeKey);
-      t.is(routeList[0].name, 'todos');
-      t.is(routeList[1].name, 'todo');
-    });
+  store.dispatch(routeTo('/todos/123')).then(() => {
+    const router = store.getState().router;
+    t.is(router.current.url, '/todos/123');
+    t.same(router.current.params, { id: '123' });
+    const routeList = findRoutes(routes, router.current.routeKey);
+    t.is(routeList[0].name, 'todos');
+    t.is(routeList[1].name, 'todo');
+  });
 });
 
 test('dispatch routeTo with state', t => {
   const store = createStoreWithMiddleware(reducer);
-  const result = store.dispatch(routeTo('/todos', {
-    state: {count: 100}
-  }));
+  const result = store.dispatch(
+    routeTo('/todos', {
+      state: { count: 100 }
+    })
+  );
   let router = store.getState().router;
   t.is(router.next.url, '/todos');
-  t.same(router.next.state, {count: 100});
+  t.same(router.next.state, { count: 100 });
   t.is(router.current, null);
-  return result
-    .then(() => {
-      router = store.getState().router;
-      t.is(router.current.url, '/todos');
-      t.same(router.current.state, {count: 100});
-    });
+  return result.then(() => {
+    router = store.getState().router;
+    t.is(router.current.url, '/todos');
+    t.same(router.current.state, { count: 100 });
+  });
 });
 
 test('dispatch to same as current url should be no-op', t => {
   const store = createStoreWithMiddleware(reducer);
-  return store.dispatch(routeTo('/todos'))
+  return store
+    .dispatch(routeTo('/todos'))
     .then(() => {
       return store.dispatch(routeTo('/todos'));
     })
@@ -123,11 +122,10 @@ test('dispatch with right-click should be no-op', t => {
         }
       })
     )
-  )
-    .then(() => {
-      const router = store.getState().router;
-      t.is(router.current, null);
-    });
+  ).then(() => {
+    const router = store.getState().router;
+    t.is(router.current, null);
+  });
 });
 
 test('dispatch with meta-click should be no-op', t => {
@@ -140,31 +138,35 @@ test('dispatch with meta-click should be no-op', t => {
         }
       })
     )
-  )
-    .then(() => {
-      const router = store.getState().router;
-      t.is(router.current, null);
-    });
+  ).then(() => {
+    const router = store.getState().router;
+    t.is(router.current, null);
+  });
 });
 
 test('dispatch to same as current url with new state should not be a no-op', t => {
   const store = createStoreWithMiddleware(reducer);
-  return store.dispatch(routeTo('/todos', {
-    state: {
-      count: 100
-    }
-  }))
-    .then(() => {
-      return store.dispatch(routeTo('/todos', {
+  return store
+    .dispatch(
+      routeTo('/todos', {
         state: {
-          count: 200
+          count: 100
         }
-      }));
+      })
+    )
+    .then(() => {
+      return store.dispatch(
+        routeTo('/todos', {
+          state: {
+            count: 200
+          }
+        })
+      );
     })
     .then(() => {
       const router = store.getState().router;
-      t.same(router.previous.state, {count: 100});
-      t.same(router.current.state, {count: 200});
+      t.same(router.previous.state, { count: 100 });
+      t.same(router.current.state, { count: 200 });
     });
 });
 
@@ -180,7 +182,8 @@ test('dispatch to same as next url should be no-op', t => {
 
 test('allow overwriting route', t => {
   const store = createStoreWithMiddleware(reducer);
-  return store.dispatch(routeTo('/one'))
+  return store
+    .dispatch(routeTo('/one'))
     .then(() => {
       store.dispatch(routeTo('/two'));
       const newResult = store.dispatch(routeTo('/three'));
@@ -195,7 +198,8 @@ test('allow overwriting route', t => {
 
 test('allow overwriting route with previous', t => {
   const store = createStoreWithMiddleware(reducer);
-  return store.dispatch(routeTo('/one'))
+  return store
+    .dispatch(routeTo('/one'))
     .then(() => {
       store.dispatch(routeTo('/two'));
       const newResult = store.dispatch(routeTo('/one'));
@@ -227,20 +231,16 @@ test('put exit in state and then exit', t => {
 
 test('modify next route with exit', t => {
   const store = createStoreWithMiddleware(reducer);
-  (
-    () => {
-      store.dispatch(routeTo('/one'));
-      const { router } = store.getState();
-      t.false(!!router.next.exit);
-    }
-  )();
-  (
-    () => {
-      store.dispatch(routeTo('/one', { exit: true }));
-      const { router } = store.getState();
-      t.true(router.next.exit);
-    }
-  )();
+  (() => {
+    store.dispatch(routeTo('/one'));
+    const { router } = store.getState();
+    t.false(!!router.next.exit);
+  })();
+  (() => {
+    store.dispatch(routeTo('/one', { exit: true }));
+    const { router } = store.getState();
+    t.true(router.next.exit);
+  })();
 });
 
 test('pick up in-flight promise', t => {
@@ -263,27 +263,30 @@ test('call onEnter, onLeave', t => {
   const onLeaveChild1Spy = sinon.spy();
   const onEnterChild2Spy = sinon.spy();
   const onLeaveChild2Spy = sinon.spy();
-  const store = createStore(reducer, applyMiddleware(
-    createRouterMiddleware({
-      routes: {
-        '/a': {
-          onEnter: onEnterParentSpy,
-          onLeave: onLeaveParentSpy,
-          routes: {
-            'nested1': {
-              onEnter: onEnterChild1Spy,
-              onLeave: onLeaveChild1Spy
-            },
-            'nested2': {
-              onEnter: onEnterChild2Spy,
-              onLeave: onLeaveChild2Spy
+  const store = createStore(
+    reducer,
+    applyMiddleware(
+      createRouterMiddleware({
+        routes: {
+          '/a': {
+            onEnter: onEnterParentSpy,
+            onLeave: onLeaveParentSpy,
+            routes: {
+              nested1: {
+                onEnter: onEnterChild1Spy,
+                onLeave: onLeaveChild1Spy
+              },
+              nested2: {
+                onEnter: onEnterChild2Spy,
+                onLeave: onLeaveChild2Spy
+              }
             }
-          }
-        },
-        '/b': {}
-      }
-    })
-  ));
+          },
+          '/b': {}
+        }
+      })
+    )
+  );
   return Promise.resolve()
     .then(() => {
       return store.dispatch(routeTo('/a/nested1'));
@@ -341,9 +344,7 @@ test('fetch async routes', t => {
 
   middleware.onRoutesChanged(routesChangedSpy);
 
-  const store = createStore(reducer, applyMiddleware(
-    middleware
-  ));
+  const store = createStore(reducer, applyMiddleware(middleware));
 
   return Promise.resolve()
     .then(() => {
@@ -359,4 +360,45 @@ test('fetch async routes', t => {
       t.is(router.current.params.id, '123');
       t.is(router.current.name, 'todo');
     });
+});
+
+test.only('resolve the origin if `ssrMode` is enabled', t => {
+  const routes = {
+    '/home': {
+      name: 'home'
+    },
+    '/apps': {
+      name: 'apps'
+    }
+  };
+
+  const store = createStore(
+    reducer,
+    {
+      router: {
+        current: {
+          params: {},
+          query: {},
+          _routeId: 5,
+          routeKey: ['/home'],
+          location: {},
+          url: '/home',
+          state: null,
+          replace: false
+        },
+        previous: null,
+        next: null
+      }
+    },
+    applyMiddleware(
+      createRouterMiddleware({
+        routes,
+        ssrMode: false
+      })
+    )
+  );
+
+  setTimeout(() => {
+    t.is(store.getState().router.origin !== undefined);
+  }, 0);
 });

--- a/test/reducer.js
+++ b/test/reducer.js
@@ -3,9 +3,13 @@ import test from 'ava';
 import 'babel-core/register';
 
 import reducer from 'redux-router-kit/src/reducer';
-import { ROUTE_TO_NEXT, ROUTE_TO, MODIFY_ROUTE } from 'redux-router-kit/src/ActionTypes';
+import {
+  ROUTE_TO_NEXT,
+  ROUTE_TO,
+  MODIFY_ROUTE
+} from 'redux-router-kit/src/ActionTypes';
 
-const createRouteAction = (options) => ({
+const createRouteAction = options => ({
   type: options.type,
   payload: {
     replace: !!options.replace,
@@ -24,15 +28,17 @@ const createRouteAction = (options) => ({
   }
 });
 
-const createRouteToNextAction = (options) => createRouteAction({
-  type: ROUTE_TO_NEXT,
-  ...options
-});
+const createRouteToNextAction = options =>
+  createRouteAction({
+    type: ROUTE_TO_NEXT,
+    ...options
+  });
 
-const createRouteToAction = (options) => createRouteAction({
-  type: ROUTE_TO,
-  ...options
-});
+const createRouteToAction = options =>
+  createRouteAction({
+    type: ROUTE_TO,
+    ...options
+  });
 
 test('initial state', t => {
   const state = reducer();
@@ -45,10 +51,13 @@ test('initial state', t => {
 
 test('route to next', t => {
   let state = reducer();
-  state = reducer(state, createRouteToNextAction({
-    _routeId: 1,
-    url: '/users'
-  }));
+  state = reducer(
+    state,
+    createRouteToNextAction({
+      _routeId: 1,
+      url: '/users'
+    })
+  );
   t.is(state.previous, null);
   t.is(state.current, null);
   t.is(state.next.url, '/users');
@@ -59,29 +68,38 @@ test('route to next', t => {
 
 test('route to next with state', t => {
   let state = reducer();
-  state = reducer(state, createRouteToNextAction({
-    _routeId: 1,
-    url: '/users',
-    state: {count: 100}
-  }));
+  state = reducer(
+    state,
+    createRouteToNextAction({
+      _routeId: 1,
+      url: '/users',
+      state: { count: 100 }
+    })
+  );
   t.is(state.previous, null);
   t.is(state.current, null);
   t.is(state.next.url, '/users');
-  t.same(state.next.state, {count: 100});
+  t.same(state.next.state, { count: 100 });
   t.is(state.next._routeId, 1);
   t.is(state.next.location.origin, 'https://example.com');
 });
 
 test('route to', t => {
   let state = reducer();
-  state = reducer(state, createRouteToNextAction({
-    _routeId: 1,
-    url: '/users'
-  }));
-  state = reducer(state, createRouteToAction({
-    _routeId: 1,
-    url: '/users'
-  }));
+  state = reducer(
+    state,
+    createRouteToNextAction({
+      _routeId: 1,
+      url: '/users'
+    })
+  );
+  state = reducer(
+    state,
+    createRouteToAction({
+      _routeId: 1,
+      url: '/users'
+    })
+  );
 
   t.is(state.previous, null);
   t.is(state.next, null);
@@ -89,10 +107,13 @@ test('route to', t => {
   t.is(state.current._routeId, 1);
   t.is(state.current.location.origin, 'https://example.com');
 
-  state = reducer(state, createRouteToAction({
-    _routeId: 2,
-    url: '/users/joe'
-  }));
+  state = reducer(
+    state,
+    createRouteToAction({
+      _routeId: 2,
+      url: '/users/joe'
+    })
+  );
 
   t.is(state.current.url, '/users/joe');
   t.is(state.current._routeId, 2);
@@ -104,74 +125,98 @@ test('route to', t => {
 
 test('route to with state', t => {
   let state = reducer();
-  state = reducer(state, createRouteToNextAction({
-    _routeId: 1,
-    url: '/users',
-    state: {count: 100}
-  }));
-  state = reducer(state, createRouteToAction({
-    _routeId: 1,
-    url: '/users',
-    state: {count: 100}
-  }));
+  state = reducer(
+    state,
+    createRouteToNextAction({
+      _routeId: 1,
+      url: '/users',
+      state: { count: 100 }
+    })
+  );
+  state = reducer(
+    state,
+    createRouteToAction({
+      _routeId: 1,
+      url: '/users',
+      state: { count: 100 }
+    })
+  );
 
   t.is(state.previous, null);
   t.is(state.next, null);
   t.is(state.current.url, '/users');
-  t.same(state.current.state, {count: 100});
+  t.same(state.current.state, { count: 100 });
   t.is(state.current._routeId, 1);
   t.is(state.current.location.origin, 'https://example.com');
 
-  state = reducer(state, createRouteToAction({
-    _routeId: 2,
-    url: '/users/joe'
-  }));
+  state = reducer(
+    state,
+    createRouteToAction({
+      _routeId: 2,
+      url: '/users/joe'
+    })
+  );
 
   t.is(state.current.url, '/users/joe');
   t.is(state.current.state, null);
   t.is(state.current._routeId, 2);
   t.is(state.current.location.origin, 'https://example.com');
   t.is(state.previous.url, '/users');
-  t.same(state.previous.state, {count: 100});
+  t.same(state.previous.state, { count: 100 });
   t.is(state.previous._routeId, 1);
   t.is(state.previous.location.origin, 'https://example.com');
 });
 
 test('replace', t => {
   let state = reducer();
-  state = reducer(state, createRouteToAction({
-    _routeId: 1,
-    url: '/users'
-  }));
-  state = reducer(state, createRouteToAction({
-    _routeId: 2,
-    url: '/users/joe'
-  }));
-  state = reducer(state, createRouteToAction({
-    _routeId: 3,
-    url: '/users/joseph',
-    replace: true
-  }));
+  state = reducer(
+    state,
+    createRouteToAction({
+      _routeId: 1,
+      url: '/users'
+    })
+  );
+  state = reducer(
+    state,
+    createRouteToAction({
+      _routeId: 2,
+      url: '/users/joe'
+    })
+  );
+  state = reducer(
+    state,
+    createRouteToAction({
+      _routeId: 3,
+      url: '/users/joseph',
+      replace: true
+    })
+  );
   t.is(state.current.url, '/users/joseph');
   t.is(state.previous.url, '/users');
 });
 
 test('put exit in state', t => {
   let state = reducer();
-  state = reducer(state, createRouteToNextAction({
-    _routeId: 1,
-    url: '/users',
-    exit: true
-  }));
+  state = reducer(
+    state,
+    createRouteToNextAction({
+      _routeId: 1,
+      url: '/users',
+      exit: true
+    })
+  );
   t.true(state.next.exit);
 });
 
 test('modify with exit', t => {
   let state = reducer();
-  state = reducer(state, createRouteToNextAction({
-    _routeId: 1,
-    url: '/users'
-  }));
+  state = reducer(
+    state,
+    createRouteToNextAction({
+      _routeId: 1,
+      url: '/users'
+    })
+  );
   state = reducer(state, {
     type: MODIFY_ROUTE,
     payload: {

--- a/test/server-side.js
+++ b/test/server-side.js
@@ -11,30 +11,31 @@ import createRouterMiddleware from 'redux-router-kit/src/middleware/createRouter
 import { routeTo } from 'redux-router-kit/src/Actions';
 import RouterContainer from 'redux-router-kit/src/components/RouterContainer';
 
+const routes = {
+  '/': () => <div>Home</div>
+};
+
+const store = createStore(
+  combineReducers({
+    router: routerReducer
+  }),
+  applyMiddleware(createRouterMiddleware({ routes, ssrMode: true }))
+);
+
 test('render route to string', t => {
-  const Home = React.createClass({
-    render() {
-      return <div>Home</div>;
-    }
+  return store.dispatch(routeTo('/')).then(() => {
+    const htmlString = renderToStaticMarkup(
+      <Provider store={store}>
+        <RouterContainer routes={routes} />
+      </Provider>
+    );
+
+    t.is(htmlString, '<div>Home</div>');
   });
-  const routes = {
-    '/': Home
-  };
-  const store = createStore(
-    combineReducers({
-      router: routerReducer
-    }),
-    applyMiddleware(
-      createRouterMiddleware({routes})
-    )
-  );
-  return store.dispatch(routeTo('/'))
-    .then(() => {
-      const htmlString = renderToStaticMarkup(
-        <Provider store={store}>
-          <RouterContainer routes={routes}/>
-        </Provider>
-      );
-      t.is(htmlString, '<div>Home</div>');
-    });
+});
+
+test('it should not set the `router.origin` in SSR mode', t => {
+  return store.dispatch(routeTo('/')).then(() => {
+    t.is(store.getState().router.origin, undefined);
+  });
 });


### PR DESCRIPTION
Prettier-on-save is butchering this PR..

This makes the following changes:
- [Adds SSR flag to createRouterMiddleware](https://github.com/zapier/redux-router-kit/blob/a703b7d5e358e82216c516e5d983d8de2244c20a/src/middleware/createRouterMiddleware.js#L117)
- If [SSR mode === `true` then no `location` information is stored](https://github.com/zapier/redux-router-kit/blob/a703b7d5e358e82216c516e5d983d8de2244c20a/src/middleware/createRouterMiddleware.js#L209-L216)
- Upon [creation of the router middleware on the client (e.g. `ssrMode === false`](https://github.com/zapier/redux-router-kit/blob/a703b7d5e358e82216c516e5d983d8de2244c20a/src/middleware/createRouterMiddleware.js#L493-L506) there is a `MODIFY_LOCATION` action fired
- Which then will [set the location and origin details](https://github.com/zapier/redux-router-kit/blob/a703b7d5e358e82216c516e5d983d8de2244c20a/src/reducer.js#L121-L135)


