### PR TITLE
Fix hash changing

### DIFF
--- a/src/utils/isOnlyHrefHashChange.js
+++ b/src/utils/isOnlyHrefHashChange.js
@@ -7,7 +7,14 @@ const isOnlyHrefHashChange = (a, b) => {
     return false;
   }
 
-  if (!a.includes('#') || !b.includes('#')) {
+  const hasHashInA = a.includes('#');
+  const hasHashInB = b.includes('#');
+
+  if ((!hasHashInA && hasHashInB) || (hasHashInA && !hasHashInB)) {
+    return true;
+  }
+
+  if (!hasHashInA || !hasHashInB) {
     return false;
   }
 

--- a/src/utils/isOnlyHrefHashChange.js
+++ b/src/utils/isOnlyHrefHashChange.js
@@ -7,21 +7,27 @@ const isOnlyHrefHashChange = (a, b) => {
     return false;
   }
 
+  const aPath = a.split('#')[0];
+  const bPath = b.split('#')[0];
   const hasHashInA = a.includes('#');
   const hasHashInB = b.includes('#');
+
+  if (aPath !== bPath) {
+    return false;
+  }
 
   if ((!hasHashInA && hasHashInB) || (hasHashInA && !hasHashInB)) {
     return true;
   }
 
-  if (!hasHashInA || !hasHashInB) {
+  if (!hasHashInA && !hasHashInB) {
     return false;
   }
 
   // If there is a hash, but the string before the hash matches, then it is a
   // hash only change. If the hash values are mismatching, or the same, it does
   // not matter because the browser will deal with that.
-  if (a.split('#')[0] === b.split('#')[0]) {
+  if (aPath === bPath) {
     return true;
   }
 

--- a/test/utils/isOnlyHrefHashChange.js
+++ b/test/utils/isOnlyHrefHashChange.js
@@ -42,3 +42,23 @@ test('will return `false` if both strings contain a hash and the base values are
 
   t.is(result, expected);
 });
+
+test('will return `true` if only the first string contains a hash', t => {
+  const locationA = 'http://www.localhost:8000/app/explore/#/hello-world';
+  const locationB = 'http://www.localhost:8000/app/explore/';
+
+  const result = isOnlyHrefHashChange(locationA, locationB);
+  const expected = true;
+
+  t.is(result, expected);
+});
+
+test('will return `true` if only the second string contains a hash', t => {
+  const locationA = 'http://www.localhost:8000/app/explore/';
+  const locationB = 'http://www.localhost:8000/app/explore/#/hello-world';
+
+  const result = isOnlyHrefHashChange(locationA, locationB);
+  const expected = true;
+
+  t.is(result, expected);
+});

--- a/test/utils/isOnlyHrefHashChange.js
+++ b/test/utils/isOnlyHrefHashChange.js
@@ -43,7 +43,7 @@ test('will return `false` if both strings contain a hash and the base values are
   t.is(result, expected);
 });
 
-test('will return `true` if only the first string contains a hash', t => {
+test('will return `true` if the base values are identical and only the first string contains a hash', t => {
   const locationA = 'http://www.localhost:8000/app/explore/#/hello-world';
   const locationB = 'http://www.localhost:8000/app/explore/';
 
@@ -53,12 +53,32 @@ test('will return `true` if only the first string contains a hash', t => {
   t.is(result, expected);
 });
 
-test('will return `true` if only the second string contains a hash', t => {
+test('will return `true` if the base values are identical and only the second string contains a hash', t => {
   const locationA = 'http://www.localhost:8000/app/explore/';
   const locationB = 'http://www.localhost:8000/app/explore/#/hello-world';
 
   const result = isOnlyHrefHashChange(locationA, locationB);
   const expected = true;
+
+  t.is(result, expected);
+});
+
+test('will return `false` if the base values are different and only the first string contains a hash', t => {
+  const locationA = 'http://www.localhost:8000/app/explore/#/hello-world';
+  const locationB = 'http://www.localhost:8000/app/contact-us/';
+
+  const result = isOnlyHrefHashChange(locationA, locationB);
+  const expected = false;
+
+  t.is(result, expected);
+});
+
+test('will return `false` if the base values are different and only the second string contains a hash', t => {
+  const locationA = 'http://www.localhost:8000/app/contact-us/';
+  const locationB = 'http://www.localhost:8000/app/explore/#/hello-world';
+
+  const result = isOnlyHrefHashChange(locationA, locationB);
+  const expected = false;
 
   t.is(result, expected);
 });


### PR DESCRIPTION
If a route doesn't have a hash and the next route _does_ (and the paths are identical), then that should be considered a hash change. Or if a route has a hash but the next route _does not_ (and the paths are identical) then that should be considered a hash change, too.

Specifically this fixes an issue where if you're on `/some/path` and click an anchor link to `/some/path#some-anchor` the anchor wouldn't be jumped to, although the route would appropriately change. Subsequent changes to the anchor like from `/some/path#some-anchor` to `/some/path#some-other-anchor` would still work since there's an anchor in both cases.