### PR TITLE
Add `url` and `baseUrl` to error messages in `parseUrl`

### DIFF
--- a/src/utils/parseUrl.js
+++ b/src/utils/parseUrl.js
@@ -14,16 +14,19 @@ const hasScheme = url => {
 };
 
 const parseUrl = (url = '', baseUrl) => {
-
   if (!hasScheme(url)) {
     if (!hasScheme(baseUrl)) {
-      throw new Error('Must provide scheme in url or baseUrl to parse.');
+      throw new Error(
+        `Must provide scheme in url or baseUrl to parse. \`url\` provided: ${url}. \`baseUrl\` provided: ${baseUrl}.`
+      );
     }
   }
 
   if (!hasScheme(url)) {
     if (url[0] !== '/') {
-      throw new Error('Only absolute URLs are currently supported.');
+      throw new Error(
+        `Only absolute URLs are currently supported. \`url\` provided: ${url}`
+      );
     }
   }
 


### PR DESCRIPTION
Add the `url` and `baseUrl` to the error messages inside `parseUrl`. This should help debug where these errors originated.