### PR TITLE
Ignore `javascript:` links

### DIFF
--- a/src/utils/onLink.js
+++ b/src/utils/onLink.js
@@ -72,9 +72,14 @@ const onLink = (config, handler) => {
     // 2. rel="external" attribute
     if (element.hasAttribute('download') || element.getAttribute('rel') === 'external') { return false; }
 
+    const originalHref = element.getAttribute('href');
+    const sanitizedHref = originalHref.toLowerCase();
+
     // Check for mailto: in the href
-    const href = element.getAttribute('href');
-    if (href && href.indexOf('mailto:') > -1) { return false; }
+    if (sanitizedHref.indexOf('mailto:') > -1) { return false; }
+    // Check for javascript: in the href
+    // eslint-disable-next-line no-script-url
+    if (sanitizedHref.indexOf('javascript:') > -1) { return false; }
 
     // check target
     if (element.target) { return false; }
@@ -84,7 +89,7 @@ const onLink = (config, handler) => {
       return false;
     }
 
-    return href;
+    return originalHref;
   };
 
   window.addEventListener(document.ontouchstart ? 'touchstart' : 'click', function (event) {

--- a/src/utils/onLink.js
+++ b/src/utils/onLink.js
@@ -72,14 +72,13 @@ const onLink = (config, handler) => {
     // 2. rel="external" attribute
     if (element.hasAttribute('download') || element.getAttribute('rel') === 'external') { return false; }
 
-    const originalHref = element.getAttribute('href');
-    const sanitizedHref = originalHref.toLowerCase();
+    const lowerCasedHref = element.href.toLowerCase();
 
     // Check for mailto: in the href
-    if (sanitizedHref.indexOf('mailto:') > -1) { return false; }
+    if (lowerCasedHref.indexOf('mailto:') > -1) { return false; }
     // Check for javascript: in the href
     // eslint-disable-next-line no-script-url
-    if (sanitizedHref.indexOf('javascript:') > -1) { return false; }
+    if (lowerCasedHref.indexOf('javascript:') > -1) { return false; }
 
     // check target
     if (element.target) { return false; }
@@ -89,7 +88,7 @@ const onLink = (config, handler) => {
       return false;
     }
 
-    return originalHref;
+    return element.href;
   };
 
   window.addEventListener(document.ontouchstart ? 'touchstart' : 'click', function (event) {

--- a/test/utils/onLink.js
+++ b/test/utils/onLink.js
@@ -29,7 +29,7 @@ test('onLink subscribe/click/unsubscribe', t => {
 
 test('onLink should emit cross-origin links when enabled', t => {
   const node = document.createElement('div');
-  node.id = 'onLinkContaine-1';
+  node.id = 'onLinkContainer-1';
   document.body.appendChild(node);
   node.innerHTML = `
     <a id="onlink-1" href="http://www.google.com/hello">Hello</a>
@@ -71,5 +71,24 @@ test('onLink should NOT emit cross-origin links when enabled', t => {
 
   document.getElementById('onlink-2').dispatchEvent(mouseEvent);
   t.is(onLinkSpy.lastCall.args[0].href, undefined);
+  unsubscribe();
+});
+
+test('onLink should NOT emit JavaScript links', t => {
+  const node = document.createElement('div');
+  node.id = 'onLinkContainer-3';
+  document.body.appendChild(node);
+  node.innerHTML = `
+    <a id="onlink-3" href="javascript:">Hello</a>
+  `;
+  const onLinkSpy = sinon.spy();
+  const unsubscribe = onLink({ shouldEmitCrossOriginLinks: false }, onLinkSpy);
+  var mouseEvent = new document.defaultView.MouseEvent('click', {
+    view: window,
+    bubbles: true,
+    cancelable: true,
+  });
+  document.getElementById('onlink-3').dispatchEvent(mouseEvent);
+  t.true(onLinkSpy.notCalled);
   unsubscribe();
 });


### PR DESCRIPTION
We currently emit `javascript:` URLs which leads to further errors. This PR filters out those URLs

rel https://github.com/zapier/zapier/issues/17917