### PR TITLE
initial peek under the hood

### DIFF
--- a/src/middleware/createRouterMiddleware.js
+++ b/src/middleware/createRouterMiddleware.js
@@ -21,6 +21,9 @@ import matchRoutes from '../utils/matchRoutes';
 import cloneRoutesForKey from '../utils/cloneRoutesForKey';
 import isOnlyLocationHashChange from '../utils/isOnlyLocationHashChange';
 
+// Kangzes annotations & why
+// https://github.com/zapier/zapier/pull/29960#issuecomment-522404231
+
 const UNDEFINED_HREF = 'http://example.com/';
 
 let _id = 0;


### PR DESCRIPTION
A peek under the hood of `react-redux-kit` as part of [this investigation](https://github.com/zapier/zapier/pull/29960#issuecomment-522404231) into `navigate` events not firing from frontend.